### PR TITLE
동아리 임원이 동아리 가입 신청서 승인하는 기능 구현

### DIFF
--- a/src/main/java/com/cotato/squadus/api/admin/controller/ClubAdminController.java
+++ b/src/main/java/com/cotato/squadus/api/admin/controller/ClubAdminController.java
@@ -1,0 +1,23 @@
+package com.cotato.squadus.api.admin.controller;
+
+import com.cotato.squadus.api.admin.dto.ClubJoinApprovalResponse;
+import com.cotato.squadus.domain.club.admin.service.ClubAdminService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "동아리 관리", description = "동아리 관리 관련 API")
+@RestController
+@RequestMapping("/v1/api/clubs/{clubId}/admin")
+@RequiredArgsConstructor
+public class ClubAdminController {
+
+    private final ClubAdminService clubAdminService;
+
+    @PostMapping("/approval/{applicationId}")
+    public ResponseEntity<ClubJoinApprovalResponse> approveClubMember(@PathVariable Long clubId, @PathVariable Long applicationId) {
+        ClubJoinApprovalResponse clubJoinApprovalResponse = clubAdminService.approveApply(clubId, applicationId);
+        return ResponseEntity.ok(clubJoinApprovalResponse);
+    }
+}

--- a/src/main/java/com/cotato/squadus/api/admin/controller/ClubAdminController.java
+++ b/src/main/java/com/cotato/squadus/api/admin/controller/ClubAdminController.java
@@ -2,6 +2,7 @@ package com.cotato.squadus.api.admin.controller;
 
 import com.cotato.squadus.api.admin.dto.ClubJoinApprovalResponse;
 import com.cotato.squadus.domain.club.admin.service.ClubAdminService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ public class ClubAdminController {
     private final ClubAdminService clubAdminService;
 
     @PostMapping("/approval/{applicationId}")
+    @Operation(summary = "동아리 가입 신청 승인", description = "ADMIN 회원인지 검증 후 applicationId를 통해 가입을 승인합니다")
     public ResponseEntity<ClubJoinApprovalResponse> approveClubMember(@PathVariable Long clubId, @PathVariable Long applicationId) {
         ClubJoinApprovalResponse clubJoinApprovalResponse = clubAdminService.approveApply(clubId, applicationId);
         return ResponseEntity.ok(clubJoinApprovalResponse);

--- a/src/main/java/com/cotato/squadus/api/admin/dto/ClubJoinApprovalResponse.java
+++ b/src/main/java/com/cotato/squadus/api/admin/dto/ClubJoinApprovalResponse.java
@@ -1,0 +1,6 @@
+package com.cotato.squadus.api.admin.dto;
+
+public record ClubJoinApprovalResponse(
+        Long clubMemberId
+) {
+}

--- a/src/main/java/com/cotato/squadus/api/post/controller/ClubPostController.java
+++ b/src/main/java/com/cotato/squadus/api/post/controller/ClubPostController.java
@@ -51,7 +51,7 @@ public class ClubPostController {
     @Operation(summary = "동아리 공지 생성", description = "동아리 공지를 하나 생성합니다")
     public ResponseEntity<ClubPostCreateResponse> createClubPost(@PathVariable Long clubId, @RequestBody ClubPostCreateRequest clubPostCreateRequest) {
         clubMemberService.validateClubMember(clubId);
-        ClubPostCreateResponse clubPostCreateResponse = clubPostService.createClubPost(clubPostCreateRequest);
+        ClubPostCreateResponse clubPostCreateResponse = clubPostService.createClubPost(clubId, clubPostCreateRequest);
         log.info("동아리 공지 작성, postId: {} ", clubPostCreateResponse);
         return ResponseEntity.ok(clubPostCreateResponse);
     }

--- a/src/main/java/com/cotato/squadus/common/error/ErrorCode.java
+++ b/src/main/java/com/cotato/squadus/common/error/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     ROLE_IS_NOT_MATCH(HttpStatus.BAD_REQUEST, "M-101", "해당 ROLE은 변경할 수 없습니다."),
     ROLE_IS_NOT_OLD_MEMBER(HttpStatus.BAD_REQUEST, "M-103", "해당 회원의 ROLE은 OLD_MEMBER가 아닙니다."),
     SAME_PASSWORD(HttpStatus.CONFLICT, "M-301", "이전과 같은 비밀번호로 변경할 수 없습니다."),
+    MEMBER_TYPE_IS_NOT_ADMIN(HttpStatus.BAD_REQUEST, "M-102", "해당 회원은 ADMIN 회원이 아닙니다."),
 
     // 동아리 관련
     CLUB_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C-001", "해당 동아리에 접근할 수 있는 권한이 없습니다."),

--- a/src/main/java/com/cotato/squadus/domain/auth/enums/Membership.java
+++ b/src/main/java/com/cotato/squadus/domain/auth/enums/Membership.java
@@ -1,6 +1,6 @@
 package com.cotato.squadus.domain.auth.enums;
 
-public enum MemberStatus {
+public enum Membership {
     APPLIED,
     JOINED,
     QUIT

--- a/src/main/java/com/cotato/squadus/domain/club/admin/service/ClubAdminService.java
+++ b/src/main/java/com/cotato/squadus/domain/club/admin/service/ClubAdminService.java
@@ -1,0 +1,55 @@
+package com.cotato.squadus.domain.club.admin.service;
+
+import com.cotato.squadus.api.admin.dto.ClubJoinApprovalResponse;
+import com.cotato.squadus.common.error.ErrorCode;
+import com.cotato.squadus.common.error.exception.AppException;
+import com.cotato.squadus.domain.auth.enums.Membership;
+import com.cotato.squadus.domain.auth.service.ClubMemberService;
+import com.cotato.squadus.domain.club.common.entity.ClubAdminMember;
+import com.cotato.squadus.domain.club.common.entity.ClubApplication;
+import com.cotato.squadus.domain.club.common.entity.ClubMember;
+import com.cotato.squadus.domain.club.common.entity.RegularClubMember;
+import com.cotato.squadus.domain.club.common.enums.MemberType;
+import com.cotato.squadus.domain.club.common.repository.ClubApplicationRepository;
+import com.cotato.squadus.domain.club.common.repository.ClubMemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ClubAdminService {
+
+    private final ClubApplicationRepository clubApplicationRepository;
+    private final ClubMemberService clubMemberService;
+    private final ClubMemberRepository clubMemberRepository;
+
+    @Transactional
+    public ClubJoinApprovalResponse approveApply(Long clubId, Long applicationId) {
+        validateAdminMember(clubId);
+        ClubApplication clubApplication = clubApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 고유번호를 가진 지원서를 찾을 수 없습니다."));
+
+        ClubMember clubMember = RegularClubMember.builder()
+                .member(clubApplication.getMember())
+                .club(clubApplication.getClub())
+                .membership(Membership.JOINED)
+                .isPaid(false)
+                .build();
+
+        ClubMember savedMember = clubMemberRepository.save(clubMember);
+        return new ClubJoinApprovalResponse(savedMember.getClubMemberIdx());
+    }
+
+    private void validateAdminMember(Long clubId) {
+        ClubMember clubMember = clubMemberService.findClubMemberBySecurityContextHolder();
+        if (clubMember.getMemberType().equals(MemberType.MEMBER)) {
+            throw new AppException(ErrorCode.MEMBER_TYPE_IS_NOT_ADMIN);
+        }
+    }
+
+}

--- a/src/main/java/com/cotato/squadus/domain/club/common/entity/ClubAdminMember.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/entity/ClubAdminMember.java
@@ -1,18 +1,35 @@
 package com.cotato.squadus.domain.club.common.entity;
 
+import com.cotato.squadus.domain.auth.entity.Member;
 import com.cotato.squadus.domain.auth.enums.AdminStatus;
+import com.cotato.squadus.domain.auth.enums.Membership;
+import com.cotato.squadus.domain.club.common.enums.MemberType;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @DiscriminatorValue("ADMIN")
+@NoArgsConstructor
 public class ClubAdminMember extends ClubMember {
 
     @Enumerated(EnumType.STRING)
     private AdminStatus adminStatus;
+
+    @Builder
+    public ClubAdminMember(Member member, Club club, Membership membership, Boolean isPaid, String clubProfileImage, AdminStatus adminStatus) {
+        super(member, club, membership, isPaid, clubProfileImage);
+        this.adminStatus = adminStatus;
+    }
+
+    @Override
+    public MemberType getMemberType() {
+        return MemberType.ADMIN;
+    }
 
 }

--- a/src/main/java/com/cotato/squadus/domain/club/common/entity/ClubApplication.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/entity/ClubApplication.java
@@ -5,11 +5,13 @@ import com.cotato.squadus.domain.auth.entity.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(name = "club_application")
 public class ClubApplication {
 

--- a/src/main/java/com/cotato/squadus/domain/club/common/entity/ClubMember.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/entity/ClubMember.java
@@ -1,19 +1,22 @@
 package com.cotato.squadus.domain.club.common.entity;
 import com.cotato.squadus.domain.auth.entity.Member;
-import com.cotato.squadus.domain.auth.enums.MemberStatus;
+import com.cotato.squadus.domain.auth.enums.Membership;
+import com.cotato.squadus.domain.club.common.enums.MemberType;
 import com.cotato.squadus.domain.club.schedule.entity.ScheduleComment;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 import static jakarta.persistence.CascadeType.ALL;
-import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "member_type")
+@NoArgsConstructor
 @Table(name = "club_member")
 public abstract class ClubMember {
 
@@ -30,7 +33,7 @@ public abstract class ClubMember {
     private Club club;
 
     @Enumerated(EnumType.STRING)
-    private MemberStatus memberStatus;
+    private Membership membership;
 
     private Boolean isPaid;
 
@@ -39,4 +42,14 @@ public abstract class ClubMember {
 
     @OneToMany(mappedBy = "clubMember", cascade = ALL)
     private List<ScheduleComment> scheduleComments;
+
+    public abstract MemberType getMemberType();
+
+    public ClubMember(Member member, Club club, Membership membership, Boolean isPaid, String clubProfileImage) {
+        this.member = member;
+        this.club = club;
+        this.membership = membership;
+        this.isPaid = isPaid;
+        this.clubProfileImage = clubProfileImage;
+    }
 }

--- a/src/main/java/com/cotato/squadus/domain/club/common/entity/RegularClubMember.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/entity/RegularClubMember.java
@@ -1,15 +1,27 @@
 package com.cotato.squadus.domain.club.common.entity;
 
-import com.cotato.squadus.domain.auth.enums.MemberStatus;
+import com.cotato.squadus.domain.auth.entity.Member;
+import com.cotato.squadus.domain.auth.enums.Membership;
+import com.cotato.squadus.domain.club.common.enums.MemberType;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @DiscriminatorValue("MEMBER")
 public class RegularClubMember extends ClubMember {
 
+    @Builder
+    public RegularClubMember(Member member, Club club, Membership membership, Boolean isPaid, String clubProfileImage) {
+        super(member, club, membership, isPaid, clubProfileImage);
+    }
+
+    @Override
+    public MemberType getMemberType() {
+        return MemberType.MEMBER;
+    }
 }

--- a/src/main/java/com/cotato/squadus/domain/club/common/enums/MemberType.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/enums/MemberType.java
@@ -1,0 +1,5 @@
+package com.cotato.squadus.domain.club.common.enums;
+
+public enum MemberType {
+    ADMIN, MEMBER
+}

--- a/src/main/java/com/cotato/squadus/domain/club/common/service/ClubService.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/service/ClubService.java
@@ -14,15 +14,15 @@ import com.cotato.squadus.domain.club.common.entity.Club;
 import com.cotato.squadus.domain.club.common.entity.ClubApplication;
 import com.cotato.squadus.domain.auth.entity.Member;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
+import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ClubService {
 

--- a/src/main/java/com/cotato/squadus/domain/club/post/service/ClubPostService.java
+++ b/src/main/java/com/cotato/squadus/domain/club/post/service/ClubPostService.java
@@ -4,6 +4,8 @@ import com.cotato.squadus.api.post.dto.*;
 import com.cotato.squadus.common.error.ErrorCode;
 import com.cotato.squadus.common.error.exception.AppException;
 import com.cotato.squadus.domain.auth.service.ClubMemberService;
+import com.cotato.squadus.domain.club.common.entity.Club;
+import com.cotato.squadus.domain.club.common.repository.ClubRepository;
 import com.cotato.squadus.domain.club.post.entity.ClubPost;
 import com.cotato.squadus.domain.club.post.repository.ClubPostRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -12,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
+
 @Slf4j
 @Service
 @Transactional(readOnly = true)
@@ -20,6 +23,7 @@ public class ClubPostService {
 
     private final ClubPostRepository clubPostRepository;
     private final ClubMemberService clubMemberService;
+    private final ClubRepository clubRepository;
 
     // 공지 전체 내용 조회
     public ClubPostListResponse findAllClubPostsByClubId(Long clubId) {
@@ -53,8 +57,11 @@ public class ClubPostService {
     }
 
     @Transactional
-    public ClubPostCreateResponse createClubPost(ClubPostCreateRequest clubPostCreateRequest) {
+    public ClubPostCreateResponse createClubPost(Long clubId, ClubPostCreateRequest clubPostCreateRequest) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 고유번호를 가진 동아리를 찾을 수 없습니다."));
         ClubPost clubPost = ClubPost.builder()
+                .club(club)
                 .title(clubPostCreateRequest.title())
                 .content(clubPostCreateRequest.content())
                 .image(clubPostCreateRequest.imageUrl())


### PR DESCRIPTION
ClubMember가 둘로 나뉨(single table, abstract class)
-RegularClubMember(MemberType: MEMBER)
-ClubAdminMember(MemberType:  ADMIN)

MemberType으로 둘을 구분 하는데 
@DiscriminatorColumn(name = "member_type")
이렇게 되어있기 때문에 따로 MemberType Enum을 생성해서 getMemberType을 사용할 수 있도록 했음

MemberStatus보다 Membership이 더 직관적인 것 같아서 이름 바꿈

