### PR TITLE
동아리 기본 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/cotato/squadus/api/club/controller/ClubController.java
+++ b/src/main/java/com/cotato/squadus/api/club/controller/ClubController.java
@@ -1,9 +1,6 @@
 package com.cotato.squadus.api.club.controller;
 
-import com.cotato.squadus.api.club.dto.ClubCreateRequest;
-import com.cotato.squadus.api.club.dto.ClubCreateResponse;
-import com.cotato.squadus.api.club.dto.ClubApplyRequest;
-import com.cotato.squadus.api.club.dto.ClubApplyResponse;
+import com.cotato.squadus.api.club.dto.*;
 import com.cotato.squadus.domain.club.common.service.ClubService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +21,13 @@ public class ClubController {
     public ResponseEntity<ClubCreateResponse> createClub(@RequestBody ClubCreateRequest clubCreateRequest) {
         ClubCreateResponse clubCreateResponse = clubService.createClub(clubCreateRequest);
         return ResponseEntity.ok(clubCreateResponse);
+    }
+
+    @GetMapping("/{clubId}")
+    @Operation(summary = "동아리 기본 정보 조회", description = "clubId를 바탕으로 동아리에 대한 정보를 반환합니다.")
+    public ResponseEntity<ClubInfoResponse> findClubInfo(@PathVariable Long clubId) {
+        ClubInfoResponse clubInfoResponse = clubService.findClubInfo(clubId);
+        return ResponseEntity.ok(clubInfoResponse);
     }
 
     @PostMapping("/{clubId}")

--- a/src/main/java/com/cotato/squadus/api/club/dto/ClubInfoResponse.java
+++ b/src/main/java/com/cotato/squadus/api/club/dto/ClubInfoResponse.java
@@ -1,0 +1,36 @@
+package com.cotato.squadus.api.club.dto;
+
+import com.cotato.squadus.domain.club.common.entity.Club;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ClubInfoResponse(
+        Long id,
+        String clubName,
+        String university,
+        String clubTier,
+        Integer clubRank,
+        String sportsCategory,
+        String logo,
+        Integer numberOfMembers,
+        LocalDateTime createdAt,
+        String clubMessage,
+        List<String> tags
+) {
+    public static ClubInfoResponse from(Club club) {
+        return new ClubInfoResponse(
+                club.getClubId(),
+                club.getClubName(),
+                club.getUniversity(),
+                club.getClubTier().name(),
+                club.getClubRank(),
+                club.getSportsCategory().name(),
+                club.getLogo(),
+                club.getClubMembers() != null ? club.getClubMembers().size() : 0,
+                club.getCreatedAt(),
+                club.getClubMessage(),
+                club.getTags()
+        );
+    }
+}

--- a/src/main/java/com/cotato/squadus/api/club/dto/ClubInfoResponse.java
+++ b/src/main/java/com/cotato/squadus/api/club/dto/ClubInfoResponse.java
@@ -14,6 +14,7 @@ public record ClubInfoResponse(
         String sportsCategory,
         String logo,
         Integer numberOfMembers,
+        Long maxMembers,
         LocalDateTime createdAt,
         String clubMessage,
         List<String> tags
@@ -28,6 +29,7 @@ public record ClubInfoResponse(
                 club.getSportsCategory().name(),
                 club.getLogo(),
                 club.getClubMembers() != null ? club.getClubMembers().size() : 0,
+                club.getMaxMembers(),
                 club.getCreatedAt(),
                 club.getClubMessage(),
                 club.getTags()

--- a/src/main/java/com/cotato/squadus/domain/club/admin/service/ClubAdminService.java
+++ b/src/main/java/com/cotato/squadus/domain/club/admin/service/ClubAdminService.java
@@ -3,15 +3,14 @@ package com.cotato.squadus.domain.club.admin.service;
 import com.cotato.squadus.api.admin.dto.ClubJoinApprovalResponse;
 import com.cotato.squadus.common.error.ErrorCode;
 import com.cotato.squadus.common.error.exception.AppException;
+import com.cotato.squadus.domain.auth.enums.ApplicationStatus;
 import com.cotato.squadus.domain.auth.enums.Membership;
 import com.cotato.squadus.domain.auth.service.ClubMemberService;
-import com.cotato.squadus.domain.club.common.entity.ClubAdminMember;
-import com.cotato.squadus.domain.club.common.entity.ClubApplication;
-import com.cotato.squadus.domain.club.common.entity.ClubMember;
-import com.cotato.squadus.domain.club.common.entity.RegularClubMember;
+import com.cotato.squadus.domain.club.common.entity.*;
 import com.cotato.squadus.domain.club.common.enums.MemberType;
 import com.cotato.squadus.domain.club.common.repository.ClubApplicationRepository;
 import com.cotato.squadus.domain.club.common.repository.ClubMemberRepository;
+import com.cotato.squadus.domain.club.common.repository.ClubRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,10 +26,12 @@ public class ClubAdminService {
     private final ClubApplicationRepository clubApplicationRepository;
     private final ClubMemberService clubMemberService;
     private final ClubMemberRepository clubMemberRepository;
+    private final ClubRepository clubRepository;
 
     @Transactional
     public ClubJoinApprovalResponse approveApply(Long clubId, Long applicationId) {
         validateAdminMember(clubId);
+
         ClubApplication clubApplication = clubApplicationRepository.findById(applicationId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 고유번호를 가진 지원서를 찾을 수 없습니다."));
 
@@ -42,7 +43,21 @@ public class ClubAdminService {
                 .build();
 
         ClubMember savedMember = clubMemberRepository.save(clubMember);
+
+        updateClubInfo(clubId, savedMember);
+        clubApplication.updateApplicationState(ApplicationStatus.APPROVED);
+        clubApplicationRepository.save(clubApplication);
         return new ClubJoinApprovalResponse(savedMember.getClubMemberIdx());
+    }
+
+    // 신규 가입한 동아리원에 대한 정보 반영
+    private void updateClubInfo(Long clubId, ClubMember clubMember) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 고유번호를 가진 동아리를 찾을 수 없습니다."));
+
+        club.addClubMember(clubMember);
+        club.addNumberOfMembers();
+        clubRepository.save(club);
     }
 
     private void validateAdminMember(Long clubId) {

--- a/src/main/java/com/cotato/squadus/domain/club/common/entity/Club.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/entity/Club.java
@@ -34,7 +34,10 @@ public class Club extends BaseTimeEntity {
 
     private Integer clubRank;
 
+    @Lob
     private String clubMessage;
+
+    private Long maxMembers;
 
     private Integer numberOfMembers;
 
@@ -57,12 +60,23 @@ public class Club extends BaseTimeEntity {
     private List<ClubPost> clubPosts;
 
     @Builder
-    private Club(String clubName, String university, SportsCategory sportsCategory, String logo, ClubTier clubTier, Integer clubRank) {
+    private Club(String clubName, String university, SportsCategory sportsCategory, String logo, ClubTier clubTier, Integer clubRank, String clubMessage, Long maxMembers) {
         this.clubName = clubName;
         this.university = university;
         this.sportsCategory = sportsCategory;
         this.logo = logo;
         this.clubTier = clubTier;
         this.clubRank = clubRank;
+        this.clubMessage = clubMessage;
+        this.maxMembers = maxMembers;
+        this.numberOfMembers = 0;
+    }
+
+    public void addClubMember(ClubMember clubMember) {
+        this.clubMembers.add(clubMember);
+    }
+
+    public void addNumberOfMembers() {
+        this.numberOfMembers++;
     }
 }

--- a/src/main/java/com/cotato/squadus/domain/club/common/entity/Club.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/entity/Club.java
@@ -34,6 +34,13 @@ public class Club extends BaseTimeEntity {
 
     private Integer clubRank;
 
+    private String clubMessage;
+
+    private Integer numberOfMembers;
+
+    @ElementCollection
+    private List<String> tags; // 별도의 테이블을 생성하여 컬렉션의 데이터를 저장
+
     @Enumerated(EnumType.STRING)
     private SportsCategory sportsCategory;
 

--- a/src/main/java/com/cotato/squadus/domain/club/common/entity/ClubApplication.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/entity/ClubApplication.java
@@ -38,4 +38,8 @@ public class ClubApplication {
         this.appliedAt = appliedAt;
         this.applicationStatus = applicationStatus;
     }
+
+    public void updateApplicationState(ApplicationStatus status) {
+        this.applicationStatus = status;
+    }
 }

--- a/src/main/java/com/cotato/squadus/domain/club/common/service/ClubService.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/service/ClubService.java
@@ -1,7 +1,6 @@
 package com.cotato.squadus.domain.club.common.service;
 
 import com.cotato.squadus.api.club.dto.*;
-import com.cotato.squadus.common.config.auth.CustomOAuth2Member;
 import com.cotato.squadus.domain.auth.repository.MemberRepository;
 import com.cotato.squadus.domain.club.common.enums.ClubTier;
 import com.cotato.squadus.domain.club.common.enums.SportsCategory;
@@ -14,7 +13,6 @@ import com.cotato.squadus.domain.auth.entity.Member;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;

--- a/src/main/java/com/cotato/squadus/domain/club/common/service/ClubService.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/service/ClubService.java
@@ -1,6 +1,7 @@
 package com.cotato.squadus.domain.club.common.service;
 
 import com.cotato.squadus.api.club.dto.*;
+import com.cotato.squadus.common.config.auth.CustomOAuth2Member;
 import com.cotato.squadus.domain.auth.repository.MemberRepository;
 import com.cotato.squadus.domain.club.common.enums.ClubTier;
 import com.cotato.squadus.domain.club.common.enums.SportsCategory;
@@ -13,6 +14,7 @@ import com.cotato.squadus.domain.auth.entity.Member;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
@@ -40,10 +42,12 @@ public class ClubService {
                 .sportsCategory(SportsCategory.valueOf(clubCreateRequest.getSportsCategory()))
                 .logo(clubCreateRequest.getLogo())
                 .clubTier(ClubTier.BRONZE)
+                .clubMessage(clubCreateRequest.getClubName() + "입니다.")
+                .maxMembers(40L)
                 .build();
 
         Club savedClub = clubRepository.save(club);
-        log.info("Club created : {}", savedClub);
+        log.info("동아리 생성됨, clubId : {}", savedClub.getClubId());
         return new ClubCreateResponse(savedClub.getClubId());
     }
 

--- a/src/main/java/com/cotato/squadus/domain/club/common/service/ClubService.java
+++ b/src/main/java/com/cotato/squadus/domain/club/common/service/ClubService.java
@@ -1,14 +1,11 @@
 package com.cotato.squadus.domain.club.common.service;
 
+import com.cotato.squadus.api.club.dto.*;
 import com.cotato.squadus.domain.auth.repository.MemberRepository;
 import com.cotato.squadus.domain.club.common.enums.ClubTier;
 import com.cotato.squadus.domain.club.common.enums.SportsCategory;
 import com.cotato.squadus.domain.club.common.repository.ClubApplicationRepository;
 import com.cotato.squadus.domain.club.common.repository.ClubRepository;
-import com.cotato.squadus.api.club.dto.ClubCreateRequest;
-import com.cotato.squadus.api.club.dto.ClubCreateResponse;
-import com.cotato.squadus.api.club.dto.ClubApplyRequest;
-import com.cotato.squadus.api.club.dto.ClubApplyResponse;
 import com.cotato.squadus.domain.auth.enums.ApplicationStatus;
 import com.cotato.squadus.domain.club.common.entity.Club;
 import com.cotato.squadus.domain.club.common.entity.ClubApplication;
@@ -71,6 +68,15 @@ public class ClubService {
                 .build();
         ClubApplication savedApplication = clubApplicationRepository.save(clubApplication);
         return new ClubApplyResponse(savedApplication.getApplicationIdx());
+    }
+
+    public ClubInfoResponse findClubInfo(Long clubId) {
+
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 고유번호를 가진 동아리를 찾을 수 없습니다."));
+
+        ClubInfoResponse clubInfoResponse = ClubInfoResponse.from(club);
+        return clubInfoResponse;
     }
 
 }


### PR DESCRIPTION
- 동아리 기본 정보에 동아리 최대 인원, 현재 인원수, 태그(태그는 미완성) 추가
- 동아리 생성 시 동아리 소개 기본 생성, 동아리 최대인원수 설정 구현
- 동아리 가입 승인시 동아리의 clubMember 리스트가 바뀌지않는 오류 수정(가입 승인시 신규 회원 동아리에 추가)
